### PR TITLE
自動ビルド用のGitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
+  push:
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           copy "C:\Program Files\mackoy\BveTs6\Mackoy.IInputDevice.DLL" AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.IInputDevice.DLL
           copy "C:\Program Files\mackoy\BveTs6\Mackoy.XmlInterfaces.DLL" AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.XmlInterfaces.DLL
       - name: Cache dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
         uses: NuGet/setup-nuget@v2
       - name: Restore project
         run: msbuild AtsEx.sln /t:Restore /p:Configuration=Release
-      - name: Cache dependencies
+      - name: Restore dependencies
         id: cache-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.IInputDevice.DLL
@@ -36,6 +36,13 @@ jobs:
           mkdir AtsEx.PluginHost\LocalReferences\BveTs
           copy "C:\Program Files\mackoy\BveTs6\Mackoy.IInputDevice.DLL" AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.IInputDevice.DLL
           copy "C:\Program Files\mackoy\BveTs6\Mackoy.XmlInterfaces.DLL" AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.XmlInterfaces.DLL
+      - name: Cache dependencies
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.IInputDevice.DLL
+            AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.XmlInterfaces.DLL
+          key: dependencies-1.0.0.0
       - name: Setup DllExport
         run: |
           curl -OL https://github.com/3F/DllExport/releases/download/v1.7.4/DllExport.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build
+on:
+  pull_request:
+  push:
+jobs:
+  test:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      
+      - name: Add msbuild to PATH
+        if: ${{ matrix.job.os == 'windows-latest' }}
+        uses: microsoft/setup-msbuild@v1
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
+      - name: Restore project
+        run: msbuild AtsEx.sln /t:Restore /p:Configuration=Release
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.IInputDevice.DLL
+            AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.XmlInterfaces.DLL
+          key: dependencies-1.0.0.0
+      - name: Setup dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: |
+          curl -OL https://bvets.net/archives/bvets6-msi.zip
+          7z x -obvets6 bvets6-msi.zip
+          msiexec /a bvets6\BveTs6Setup.msi /qn
+          copy C:\Program Files\mackoy\BveTs6\Mackoy.IInputDevice.DLL AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.IInputDevice.DLL
+          copy C:\Program Files\mackoy\BveTs6\Mackoy.XmlInterfaces.DLL AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.XmlInterfaces.DLL
+      - name: Setup DllExport
+        run: |
+          curl -OL https://github.com/3F/DllExport/releases/download/v1.7.4/DllExport.bat
+          .\DllExport.bat -action Restore
+      - name: Build
+        run: msbuild AtsEx.sln /p:Configuration=Release
+      - name: Package
+        run: |
+          .\package.bat
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: AtsEx-release
+          path: ./bin/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.head_ref }}
       
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v2
       - name: Restore project
@@ -56,7 +56,7 @@ jobs:
         run: |
           .\package.bat
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: AtsEx-InputPlugin-release
           path: ./bin/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
+  workflow_dispatch:
   pull_request:
-  push:
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,9 @@ jobs:
           curl -OL https://bvets.net/archives/bvets6-msi.zip
           7z x -obvets6 bvets6-msi.zip
           msiexec /a bvets6\BveTs6Setup.msi /qn
-          copy C:\Program Files\mackoy\BveTs6\Mackoy.IInputDevice.DLL AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.IInputDevice.DLL
-          copy C:\Program Files\mackoy\BveTs6\Mackoy.XmlInterfaces.DLL AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.XmlInterfaces.DLL
+          mkdir AtsEx.PluginHost\LocalReferences\BveTs
+          copy "C:\Program Files\mackoy\BveTs6\Mackoy.IInputDevice.DLL" AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.IInputDevice.DLL
+          copy "C:\Program Files\mackoy\BveTs6\Mackoy.XmlInterfaces.DLL" AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.XmlInterfaces.DLL
       - name: Setup DllExport
         run: |
           curl -OL https://github.com/3F/DllExport/releases/download/v1.7.4/DllExport.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
-  push:
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Package
         run: |
           .\package.bat
-          $Env:GITHUB_ENV += "`nGIT_HASH=" + (git rev-parse --short HEAD)
+          Add-Content -Path $env:GITHUB_ENV -Value "GIT_HASH=$(git rev-parse --short HEAD)"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
 jobs:
-  test:
+  build:
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -14,7 +14,6 @@ jobs:
           ref: ${{ github.head_ref }}
       
       - name: Add msbuild to PATH
-        if: ${{ matrix.job.os == 'windows-latest' }}
         uses: microsoft/setup-msbuild@v1
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v2
       - name: Restore project
-        run: msbuild AtsEx.sln /t:Restore /p:Configuration=Release
+        run: |
+          msbuild AtsEx.sln /t:Restore /p:Configuration=Release
+          nuget restore AtsEx.sln
       - name: Restore dependencies
         id: cache-dependencies
         uses: actions/cache/restore@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           curl -OL https://bvets.net/archives/bvets6-msi.zip
           7z x -obvets6 bvets6-msi.zip
-          msiexec /a bvets6\BveTs6Setup.msi /qn
+          cmd.exe /c start /wait msiexec /a bvets6\BveTs6Setup.msi /qn
           mkdir AtsEx.PluginHost\LocalReferences\BveTs
           copy "C:\Program Files\mackoy\BveTs6\Mackoy.IInputDevice.DLL" AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.IInputDevice.DLL
           copy "C:\Program Files\mackoy\BveTs6\Mackoy.XmlInterfaces.DLL" AtsEx.PluginHost\LocalReferences\BveTs\Mackoy.XmlInterfaces.DLL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           BVETS6: ${{ secrets.BveTs6 }}
         run: |
-          curl -OL "$env:BVETS6"
+          curl -L "$env:BVETS6" -o bvets6-msi.zip
           7z x -obvets6 bvets6-msi.zip
           cmd.exe /c start /wait msiexec /a bvets6\BveTs6Setup.msi /qn
           mkdir AtsEx.PluginHost\LocalReferences\BveTs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,5 +61,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: AtsEx-AsInputPlugin-release-${{ env.GIT_HASH }}
+          name: AtsEx-AsInputDevice-release-${{ env.GIT_HASH }}
           path: ./bin/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Package
         run: |
           .\package.bat
-          $Env:GIT_HASH = git rev-parse --short HEAD
+          $Env:GITHUB_ENV += "`nGIT_HASH=" + (git rev-parse --short HEAD)
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,9 @@ jobs:
       - name: Package
         run: |
           .\package.bat
+          $Env:GIT_HASH = git rev-parse --short HEAD
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: AtsEx-InputPlugin-release
+          name: AtsEx-AsInputPlugin-release-${{ env.GIT_HASH }}
           path: ./bin/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,10 @@ jobs:
           key: dependencies-1.0.0.0
       - name: Setup dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        env:
+          BVETS6: ${{ secrets.BveTs6 }}
         run: |
-          curl -OL https://bvets.net/archives/bvets6-msi.zip
+          curl -OL "$env:BVETS6"
           7z x -obvets6 bvets6-msi.zip
           cmd.exe /c start /wait msiexec /a bvets6\BveTs6Setup.msi /qn
           mkdir AtsEx.PluginHost\LocalReferences\BveTs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,5 +58,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: AtsEx-release
-          path: ./bin/*.zip
+          name: AtsEx-InputPlugin-release
+          path: ./bin/*

--- a/package.bat
+++ b/package.bat
@@ -1,14 +1,23 @@
-7z a bin\AtsEx.zip ..\AtsEx\AtsEx\bin\Release\*.dll -r
-7z a bin\AtsEx.zip ..\AtsEx\AtsEx\bin\Release\*.xml -r
-7z a bin\AtsEx.zip ..\AtsEx\AtsEx.PluginHost\bin\Release\*.dll -r
-7z a bin\AtsEx.zip ..\AtsEx\AtsEx.PluginHost\bin\Release\*.xml -r
-7z a bin\AtsEx.zip ..\AtsEx\AtsEx.Scripting\bin\Release\*.dll -r
-7z a bin\AtsEx.zip ..\AtsEx\AtsEx.Scripting\bin\Release\*.xml -r
-7z a bin\AtsEx.Launcher.zip ..\AtsEx\AtsEx.Launcher\bin\Release\*.dll -r
-7z a bin\AtsEx.Launcher.zip ..\AtsEx\AtsEx.Launcher\bin\Release\*.dll.config -r
-7z a bin\AtsEx.Launcher.zip ..\AtsEx\AtsEx.Launcher\bin\Release\*.xml -r
-7z a bin\AtsEx.Caller.InputDevice.zip ..\AtsEx\AtsEx.Caller.InputDevice\bin\Release\*.dll -r
-7z a bin\AtsEx.Caller.InputDevice.zip ..\AtsEx\AtsEx.Caller.InputDevice\bin\Release\*.xml -r
-7z a bin\AtsEx.SamplePlugins.zip ..\AtsEx\SamplePlugins\*\bin\Release\*.dll -r
-7z a bin\AtsEx.Extensions.zip ..\AtsEx\Extensions\*\bin\Release\*.dll -r
-7z a bin\AtsEx.Extensions.zip ..\AtsEx\Extensions\*\bin\Release\*.dll.config -r
+
+mkdir "bin\Input Devices\1.0"
+mkdir "bin\Input Devices\1.0\Resources"
+mkdir "bin\Input Devices\1.0\Extensions"
+set "dst=bin\Input Devices\"
+
+xcopy "AtsEx\bin\Release\*.dll" "%dst%\1.0" /s /y
+xcopy "AtsEx\bin\Release\*.xml" "%dst%\1.0" /s /y
+xcopy "AtsEx\Resources\*.resx" "%dst%\1.0\Resources" /s /y
+xcopy "AtsEx.PluginHost\bin\Release\*.dll" "%dst%\1.0" /s /y
+xcopy "AtsEx.PluginHost\bin\Release\*.xml" "%dst%\1.0" /s /y
+xcopy "AtsEx.PluginHost\Resources\*.resx" "%dst%\1.0\Resources" /s /y
+xcopy "AtsEx.Scripting\bin\Release\*.dll" "%dst%\1.0" /s /y
+xcopy "AtsEx.Scripting\bin\Release\*.xml" "%dst%\1.0" /s /y
+xcopy "AtsEx.Scripting\Resources\*.resx" "%dst%\1.0\Resources" /s /y
+xcopy "AtsEx.Launcher\bin\Release\*.dll" "%dst%\" /s /y
+xcopy "AtsEx.Launcher\bin\Release\*.xml" "%dst%\" /s /y
+xcopy "AtsEx.Caller.InputDevice\bin\Release\*.dll" "bin\" /s /y
+xcopy "AtsEx.Caller.InputDevice\bin\Release\*.xml" "bin\" /s /y
+
+for /d %%i in ("Extensions\*") do (
+    xcopy "%%i\bin\Release\*.dll" "%dst%\1.0\Extensions" /s /y
+)

--- a/package.bat
+++ b/package.bat
@@ -1,8 +1,7 @@
 
-mkdir "bin\Input Devices\1.0"
-mkdir "bin\Input Devices\1.0\Resources"
-mkdir "bin\Input Devices\1.0\Extensions"
-set "dst=bin\Input Devices\"
+mkdir "bin\Input Devices\AtsEx\1.0\Resources"
+mkdir "bin\Input Devices\AtsEx\1.0\Extensions"
+set "dst=bin\Input Devices\AtsEx"
 
 xcopy "AtsEx\bin\Release\*.dll" "%dst%\1.0" /s /y
 xcopy "AtsEx\bin\Release\*.xml" "%dst%\1.0" /s /y
@@ -14,9 +13,18 @@ xcopy "AtsEx.Scripting\bin\Release\*.dll" "%dst%\1.0" /s /y
 xcopy "AtsEx.Scripting\bin\Release\*.xml" "%dst%\1.0" /s /y
 xcopy "AtsEx.Scripting\Resources\*.resx" "%dst%\1.0\Resources" /s /y
 xcopy "AtsEx.Launcher\bin\Release\*.dll" "%dst%\" /s /y
+xcopy "AtsEx.Launcher\bin\Release\*.dll.config" "%dst%\" /s /y
 xcopy "AtsEx.Launcher\bin\Release\*.xml" "%dst%\" /s /y
-xcopy "AtsEx.Caller.InputDevice\bin\Release\*.dll" "bin\" /s /y
-xcopy "AtsEx.Caller.InputDevice\bin\Release\*.xml" "bin\" /s /y
+xcopy "AtsEx.Caller.InputDevice\bin\Release\*.dll" "bin\Input Devices\" /s /y
+xcopy "AtsEx.Caller.InputDevice\bin\Release\*.xml" "bin\Input Devices\" /s /y
+
+xcopy "*.svg" "%dst%\" /y
+xcopy "*.md" "%dst%\" /y
+xcopy "LICENSE" "%dst%\" /y
+
+xcopy "*.svg" "bin\" /y
+xcopy "*.md" "bin\" /y
+xcopy "LICENSE" "bin\" /y
 
 for /d %%i in ("Extensions\*") do (
     xcopy "%%i\bin\Release\*.dll" "%dst%\1.0\Extensions" /s /y

--- a/package.bat
+++ b/package.bat
@@ -1,0 +1,14 @@
+7z a bin\AtsEx.zip ..\AtsEx\AtsEx\bin\Release\*.dll -r
+7z a bin\AtsEx.zip ..\AtsEx\AtsEx\bin\Release\*.xml -r
+7z a bin\AtsEx.zip ..\AtsEx\AtsEx.PluginHost\bin\Release\*.dll -r
+7z a bin\AtsEx.zip ..\AtsEx\AtsEx.PluginHost\bin\Release\*.xml -r
+7z a bin\AtsEx.zip ..\AtsEx\AtsEx.Scripting\bin\Release\*.dll -r
+7z a bin\AtsEx.zip ..\AtsEx\AtsEx.Scripting\bin\Release\*.xml -r
+7z a bin\AtsEx.Launcher.zip ..\AtsEx\AtsEx.Launcher\bin\Release\*.dll -r
+7z a bin\AtsEx.Launcher.zip ..\AtsEx\AtsEx.Launcher\bin\Release\*.dll.config -r
+7z a bin\AtsEx.Launcher.zip ..\AtsEx\AtsEx.Launcher\bin\Release\*.xml -r
+7z a bin\AtsEx.Caller.InputDevice.zip ..\AtsEx\AtsEx.Caller.InputDevice\bin\Release\*.dll -r
+7z a bin\AtsEx.Caller.InputDevice.zip ..\AtsEx\AtsEx.Caller.InputDevice\bin\Release\*.xml -r
+7z a bin\AtsEx.SamplePlugins.zip ..\AtsEx\SamplePlugins\*\bin\Release\*.dll -r
+7z a bin\AtsEx.Extensions.zip ..\AtsEx\Extensions\*\bin\Release\*.dll -r
+7z a bin\AtsEx.Extensions.zip ..\AtsEx\Extensions\*\bin\Release\*.dll.config -r


### PR DESCRIPTION
開発段階のAtsEXを試しやすくするためにGitHub Actionsを作成しました。
実際の実行結果はこちら
https://github.com/kusaanko/AtsEX/actions/runs/8525481087
まだ成果物名がInputPluginのままだったので https://github.com/automatic9045/AtsEX/pull/35/commits/cebdc65766fc65bbf5fbb7a9153d87369d227c67 で修正しました

### 成果物として登録されるファイル
`package.bat`にて成果物としてアップロードするファイルのコピーを行っています。ここを変更すれば同梱するファイルを変更できます。

### 議論すべき点
現在BVEに付属するdllはインストーラーを実行することにより取得し、それを利用しています。
しかしこれはGitHub Actionsが実行されるたびにBVEのサイトにアクセスすることになってしまいます。
これを回避するためGitHub Actionsのcacheを利用して毎回アクセスしないようにしています。
cacheはユーザーからはダウンロードできないので二次配布には当たらないと考えています。
また、このダウンロードリンクについてはシークレットを使用するようにしています。リポジトリの設定より追加お願いします。
CI作成の上で一番問題となりそうな点を回避していますがこれでも問題ないのかは私には判断しきれません。

また、現在のトリガーはworkflow_dispatchによる手動トリガーとpull_requestに設定されています。pushは毎回実行する必要はないのでは？と考えたので削除しましたが、追加してもいいと思います。mainブランチ指定で追加してもよいかもしれません。

### ReleaseビルドかDebugビルドか？
Debugビルドにするメリットといえばブレークポイントの作成かと思いますが第3者に試してもらうときにVisual Studioを起動して試す方はいないと思い（それならソースコードからビルドして実行するほうが良い？）、実際の環境であるReleaseビルドを選択しています。